### PR TITLE
Use array destructuring in example code

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -60,7 +60,7 @@ navigator.storage.persist().then(persisted => {
 Promise.all([
   navigator.storage.persisted(),
   navigator.permissions.query({name: "persistent-storage"})
-]).then((persisted, permission) => {
+]).then(([persisted, permission]) => {
   if(!persisted &amp;&amp; permission.status == "granted") {
     navigator.storage.persist().then( /* &hellip; */ )
   } else if(!persistent &amp;&amp; permission.status == "prompt") {


### PR DESCRIPTION
`Promise.all()` resolves with an array containing all of the sub-promises' resolutions, but the code is written as if each value would be passed as individual parameters to `.then()`. In order to match the intention of the example, a destructuring assignment can be used.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jeffposnick/storage/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/storage/178d8b7...jeffposnick:fae3421.html)