### PR TITLE
Use `interface mixins` instead of `[NoInterfaceObject]`

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -221,14 +221,12 @@ user agent should alert the user and offer a way to clear <a>persistent buckets<
 <h2 id=api>API</h2>
 
 <pre class=idl>
-[SecureContext,
- NoInterfaceObject,
- Exposed=(Window,Worker)]
-interface NavigatorStorage {
+[SecureContext]
+interface mixin NavigatorStorage {
   readonly attribute StorageManager storage;
 };
-Navigator implements NavigatorStorage;
-WorkerNavigator implements NavigatorStorage;
+Navigator includes NavigatorStorage;
+WorkerNavigator includes NavigatorStorage;
 </pre>
 
 Each <a>environment settings object</a> has an associated {{StorageManager}} object.
@@ -380,6 +378,7 @@ David Grogan,
 fantasai,
 Jake Archibald<!-- technically B.J. Archibald -->,
 Jeffrey Yasskin,
+Jinho Bang,
 Jonas Sicking,
 Joshua Bell,
 Kenji Baheux,


### PR DESCRIPTION
WebIDL recently introduced dedicated syntax for mixins[1]. So, we can
replace `[NoInterfaceObject]` and `implements` with `interface mixin` and
`includes`.

This following interface is impacted by this change:
  - NavigatorStorage

This fixes #53 issue.

Test: https://github.com/w3c/web-platform-tests/pull/8702

[1] https://github.com/heycam/webidl/commit/45e8173d40ddff8dcf81697326e094bcf8b92920


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/54.html" title="Last updated on Dec 18, 2017, 3:08 PM GMT (9e79239)">Preview</a> | <a href="https://whatpr.org/storage/54/0ecf0dd...9e79239.html" title="Last updated on Dec 18, 2017, 3:08 PM GMT (9e79239)">Diff</a>