### PR TITLE
Correct branching in estimate()

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -250,7 +250,7 @@ these steps:
  {{TypeError}}.
 
  <li>
-  <p>Otherwise, run these substeps <a>in parallel</a>:
+  <p>Otherwise, run these steps <a>in parallel</a>:
 
   <ol>
    <li>
@@ -278,7 +278,7 @@ steps:
  {{TypeError}}.
 
  <li>
-  <p>Otherwise, run these substeps <a>in parallel</a>:
+  <p>Otherwise, run these steps <a>in parallel</a>:
 
   <ol>
    <li>
@@ -324,7 +324,7 @@ must run these steps:
  {{TypeError}}.
 
  <li>
-  <p>Run these substeps <a>in parallel</a>:
+  <p>Otherwise, run these steps <a>in parallel</a>:
 
   <ol>
    <li><p>Let <var>usage</var> be <a>site storage usage</a> for <var>origin</var>.


### PR DESCRIPTION
Also replace "substeps" with "steps" as we no longer make that distinction per Infra discussion.

Fixes #57.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/58.html" title="Last updated on Jan 6, 2018, 11:25 AM GMT (cd022d9)">Preview</a> | <a href="https://whatpr.org/storage/58/ef1b6ba...cd022d9.html" title="Last updated on Jan 6, 2018, 11:25 AM GMT (cd022d9)">Diff</a>