### PR TITLE
Do not use site to mean website

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -11,7 +11,7 @@ Translation: ja https://triple-underscore.github.io/storage-ja.html
 
 <h2 id=introduction>Introduction</h2>
 
-Over the years the web has grown various APIs that can be used for storage, e.g., IndexedDB,
+<p>Over the years the web has grown various APIs that can be used for storage, e.g., IndexedDB,
 <code>localStorage</code>, and <code>showNotification()</code>. The Storage Standard consolidates
 these APIs by defining:
 
@@ -83,7 +83,7 @@ Promise.all([
 
 <h2 id=infrastructure>Infrastructure</h2>
 
-A user agent has various kinds of storage:
+<p>A user agent has various kinds of semi-persistent state:
 
 <dl>
  <dt>Credentials
@@ -92,31 +92,30 @@ A user agent has various kinds of storage:
  <dd><p>Permissions for various features, such as geolocation
  <dt>Network
  <dd><p>HTTP cache, cookies, authentication entries, TLS client certificates
- <dt>Site
+ <dt>Storage
  <dd>Indexed DB, Cache API, service worker registrations, <code>localStorage</code>,
  <code>history.pushState()</code>, application caches, notifications, etc.
 </dl>
 
-This specification primarily concerns itself with <dfn export id=site-storage>site storage</dfn>.
+<p>This standard primarily concerns itself with <dfn export id=site-storage>storage</dfn>.
 
-<a>Site storage</a> consists of zero or more
-<dfn export id=site-storage-unit>site storage units</dfn>.
+<a>Storage</a> consists of zero or more <dfn export id=site-storage-unit>storage units</dfn>.
 
-Each <a for=/>origin</a> has an associated <a>site storage unit</a>. A <a>site storage unit</a>
-contains a single <dfn export id=bucket oldids=box>bucket</dfn>. [[HTML]]
+<p>Each <a for=/>origin</a> has an associated <a>storage unit</a>. A <a>storage unit</a> contains a
+single <dfn export id=bucket oldids=box>bucket</dfn>. [[HTML]]
 
 
 <h3 id=buckets oldids=boxes>Buckets</h3>
 
-A <a>bucket</a> has <dfn export for=bucket oldids=box-mode>mode</dfn> which is either
+<p>A <a>bucket</a> has <dfn export for=bucket oldids=box-mode>mode</dfn> which is either
 "<code title>best-effort</code>" or "<code title>persistent</code>". A
 <dfn export oldids=persistent-box>persistent bucket</dfn> is a <a>bucket</a> whose
 <a for=bucket>mode</a> is "<code title>persistent</code>". A
 <dfn export oldids=non-persistent-box>non-persistent bucket</dfn> is a <a>bucket</a> whose
 <a for=bucket>mode</a> is <em>not</em> "<code title>persistent</code>".
 
-A bucket is considered to be an atomic unit. Whenever a <a>bucket</a> is cleared by the user agent,
-it must be cleared in its entirety.
+<p>A <a>bucket</a> is considered to be an atomic unit. Whenever a <a>bucket</a> is cleared by the
+user agent, it must be cleared in its entirety.
 
 
 
@@ -141,53 +140,51 @@ The <dfn for="PermissionName" enum-value>"<code>persistent-storage</code>"</dfn>
 
  <dt><a>permission revocation algorithm</a></dt>
  <dd algorithm="permission-revocation">If {{"persistent-storage"}}'s <a>permission state</a> is not
- {{"granted"}}, then set the current <a for=/>origin</a>’s <a>site storage unit</a>'s
- <a>bucket</a>'s <a for=bucket>mode</a> to "<code>best-effort</code>".</dd>
+ {{"granted"}}, then set the current <a for=/>origin</a>’s <a>storage unit</a>'s <a>bucket</a>'s
+ <a for=bucket>mode</a> to "<code>best-effort</code>".</dd>
 </dl>
 
 
 
 <h2 id=usage-and-quota>Usage and quota</h2>
 
-The <dfn export>site storage usage</dfn> of an <a for=/>origin</a> <var>origin</var> is a rough
-estimate of the amount of bytes used in <var>origin</var>'s <a>site storage unit</a>.
+<p>The <dfn export>storage usage</dfn> of an <a for=/>origin</a> <var>origin</var> is a rough
+estimate of the amount of bytes used in <var>origin</var>'s <a>storage unit</a>.
 
 <p class=note>This cannot be an exact amount as user agents might, and are encouraged to, use
 deduplication, compression, and other techniques that obscure exactly how much bytes an
 <a for=/>origin</a> uses.
 
-The <dfn export>site storage quota</dfn> of an <a for=/>origin</a> <var>origin</var> is a
-conservative estimate of the amount of bytes available to <var>origin</var>'s
-<a>site storage unit</a>. This amount should be less than the total available storage space on the
-device to give users some wiggle room.
+<p>The <dfn export>storage quota</dfn> of an <a for=/>origin</a> <var>origin</var> is a conservative
+estimate of the amount of bytes available to <var>origin</var>'s <a>storage unit</a>. This amount
+should be less than the total available storage space on the device to give users some wiggle room.
 
 <p class=note>User agents are strongly encouraged to provide "popular" <a for=/>origins</a> with a
-larger <a>site storage quota</a>. Factors such as navigation frequency, recency of visits,
-bookmarking, and <a href="#persistence">permission</a> for {{"persistent-storage"}} can be used as
-indications of "popularity".
+larger <a>storage quota</a>. Factors such as navigation frequency, recency of visits, bookmarking,
+and <a href="#persistence">permission</a> for {{"persistent-storage"}} can be used as indications of
+"popularity".
 
 
 
 <h2 id=ui-guidelines>User Interface Guidelines</h2>
 
-User agents should not distinguish between network storage and <a>site storage</a> in their user
-interface. Instead user agents should offer users the ability to remove all storage for each group
-of <a>schemelessly same site</a> <a for=/>origins</a>. This ensures to some extent that network
-storage cannot be used to revive <a>site storage</a>. This also reduces the amount users need to
-know about the different ways in which sites can store data.
+User agents should not distinguish between network state and <a>storage</a> in their user interface.
+Instead user agents should offer users the ability to remove all storage for each group of
+<a>schemelessly same site</a> <a for=/>origins</a>. This ensures to some extent that network state
+cannot be used to revive <a>storage</a>. This also reduces the amount users need to know about the
+different ways in which websites can store data.
 <!-- To some extent, since HTTP ETag... And also, permissions/credentials, maybe? -->
 
-Credentials storage should be separated as it might contain data the user might not be able to
-revive, such as an autogenerated password. Since permissions storage is mostly simple booleans it
-too can be separated to avoid inconveniencing the user. Credentials and permissions are also
-somewhat easier to understand and differentiate for users from network storage and
-<a>site storage</a>.
+Credentials should be separated as they contain data the user might not be able to revive, such as
+an autogenerated password. Permissions are best separated too to avoid inconveniencing the user.
+Credentials and permissions are also somewhat easier to understand and differentiate for users from
+network state and <a>storage</a>.
 
 
 <h3 id=storage-pressure>Storage Pressure</h3>
 
-When the user agent notices it comes under storage pressure and it cannot free up sufficient space
-by clearing network storage and <a>non-persistent buckets</a> within <a>site storage</a>, then the
+<p>When the user agent notices it comes under storage pressure and it cannot free up sufficient
+space by clearing network state and <a>non-persistent buckets</a> within <a>storage</a>, then the
 user agent should alert the user and offer a way to clear <a>persistent buckets</a>.
 
 
@@ -242,8 +239,8 @@ these steps:
 
   <ol>
    <li>
-    <p>Let <var>persisted</var> be true if <var>origin</var>'s <a>site storage unit</a>'s
-    <a>bucket</a> is a <a>persistent bucket</a>, and false otherwise.
+    <p>Let <var>persisted</var> be true if <var>origin</var>'s <a>storage unit</a>'s <a>bucket</a>
+    is a <a>persistent bucket</a>, and false otherwise.
 
     <p class=note>It will be false when there's an internal error.
 
@@ -278,8 +275,8 @@ steps:
     such a scenario.
 
    <li>
-    <p>Let <var>persisted</var> be true, if <var>origin</var>'s <a>site storage unit</a>'s
-    <a>bucket</a> is a <a>persistent bucket</a>, and false otherwise.
+    <p>Let <var>persisted</var> be true, if <var>origin</var>'s <a>storage unit</a>'s <a>bucket</a>
+    is a <a>persistent bucket</a>, and false otherwise.
 
     <p class=note>It will be false when there's an internal error.
 
@@ -287,7 +284,7 @@ steps:
     <p>If <var>persisted</var> is false and <var>permission</var> is {{"granted"}}, then:
 
     <ol>
-     <li><p>Set <var>origin</var>'s <a>site storage unit</a>'s <a>bucket</a>'s <a>mode</a> to
+     <li><p>Set <var>origin</var>'s <a>storage unit</a>'s <a>bucket</a>'s <a>mode</a> to
      "<code>persistent</code>".
 
      <li><p>If there was no internal error, then set <var>persisted</var> to true.
@@ -315,9 +312,9 @@ must run these steps:
   <p>Otherwise, run these steps <a>in parallel</a>:
 
   <ol>
-   <li><p>Let <var>usage</var> be <a>site storage usage</a> for <var>origin</var>.
+   <li><p>Let <var>usage</var> be <a>storage usage</a> for <var>origin</var>.
 
-   <li><p>Let <var>quota</var> be <a>site storage quota</a> for <var>origin</var>.
+   <li><p>Let <var>quota</var> be <a>storage quota</a> for <var>origin</var>.
 
    <li><p>Let <var>dictionary</var> be a new {{StorageEstimate}} dictionary whose {{usage}} member
    is <var>usage</var> and {{quota}} member is <var>quota</var>.


### PR DESCRIPTION
HTML made site a specific authority-related term. Continuing to use it for origin-bound data would be quite confusing (and might already have been).

Closes #82.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/83.html" title="Last updated on Apr 17, 2020, 3:03 PM UTC (d3ba224)">Preview</a> | <a href="https://whatpr.org/storage/83/de5f3b1...d3ba224.html" title="Last updated on Apr 17, 2020, 3:03 PM UTC (d3ba224)">Diff</a>