### PR TITLE
history.pushState() is not a storage endpoint

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -102,7 +102,7 @@ function retrieveNextChunk(nextChunkInfo) {
  <dd><p>HTTP cache, cookies, authentication entries, TLS client certificates
  <dt id=site-storage>Storage
  <dd>Indexed DB, Cache API, service worker registrations, <code>localStorage</code>,
- <code>history.pushState()</code>, application caches, notifications, etc.
+ <code>sessionStorage</code>, application caches, notifications, etc.
 </dl>
 
 <p>This standard primarily concerns itself with storage.
@@ -605,13 +605,15 @@ dictionary StorageEstimate {
 
 <p>With that, many thanks to
 Adrian Bateman,
-Alex Russell,
 Aislinn Grigas,
+Alex Russell,
 Ali Alabbas,
+Andrew Sutherland,
 Ben Kelly,
 Ben Turner,
 Dale Harvey,
 David Grogan,
+Domenic Denicola,
 fantasai,
 Jake Archibald<!-- technically B.J. Archibald -->,
 Jeffrey Yasskin,
@@ -624,8 +626,9 @@ Luke Wagner,
 Michael Nordman,
 Mounir Lamouri,
 Shachar Zohar,
-黃強 (Shawn Huang), and
-簡冠庭 (Timothy Guan-tin Chien)
+黃強 (Shawn Huang),
+簡冠庭 (Timothy Guan-tin Chien), and
+Victor Costan
 for being awesome!
 
 <p>This standard is written by <a lang=nl href=https://annevankesteren.nl/>Anne van Kesteren</a>


### PR DESCRIPTION
Also add some folks to the Acknowledgments section for helping with the previous commit.

Closes #50.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/91.html" title="Last updated on May 15, 2020, 11:52 AM UTC (1f7ec73)">Preview</a> | <a href="https://whatpr.org/storage/91/25ac6d4...1f7ec73.html" title="Last updated on May 15, 2020, 11:52 AM UTC (1f7ec73)">Diff</a>