### PR TITLE
Minor improvement in reading flow

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -112,9 +112,9 @@ function retrieveNextChunk(nextChunkInfo) {
 <h2 id=model>Model</h2>
 
 <p>Standards defining local or session storage APIs will define a <a>storage endpoint</a> and
-<a lt="registered storage endpoints">register</a> it by changing this standard. They will use either
-<a>obtain a local storage bottle map</a> or <a>obtain a session storage bottle map</a>, which
-will give them:
+<a lt="registered storage endpoints">register</a> it by changing this standard. They will invoke either
+the <a>obtain a local storage bottle map</a> algorithm or the <a>obtain a session storage bottle map</a>
+algorithm, which will give them:
 
 <ul>
  <li><p>Failure, which might mean the API has to throw or otherwise indicate there is no storage

--- a/storage.bs
+++ b/storage.bs
@@ -112,9 +112,9 @@ function retrieveNextChunk(nextChunkInfo) {
 <h2 id=model>Model</h2>
 
 <p>Standards defining local or session storage APIs will define a <a>storage endpoint</a> and
-<a lt="registered storage endpoints">register</a> it by changing this standard. They will invoke either
-the <a>obtain a local storage bottle map</a> algorithm or the <a>obtain a session storage bottle map</a>
-algorithm, which will give them:
+<a lt="registered storage endpoints">register</a> it by changing this standard. They will invoke
+either the <a>obtain a local storage bottle map</a> or the
+<a>obtain a session storage bottle map</a> algorithm, which will give them:
 
 <ul>
  <li><p>Failure, which might mean the API has to throw or otherwise indicate there is no storage


### PR DESCRIPTION
Before this change, the rendered text reads
"they will use either obtain ...", which seems like an editing oversight
("use" should have been removed).

This is an editorial change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/105.html" title="Last updated on Jul 10, 2020, 3:06 PM UTC (be33795)">Preview</a> | <a href="https://whatpr.org/storage/105/60b30c8...be33795.html" title="Last updated on Jul 10, 2020, 3:06 PM UTC (be33795)">Diff</a>