### PR TITLE
Clarify guidance around storage quota

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -479,8 +479,9 @@ deduplication, compression, and other techniques that obscure exactly how much b
 <a>storage shelf</a> uses.
 
 <p>The <dfn export>storage quota</dfn> of a <a>storage shelf</a> is a conservative estimate of the
-total amount of bytes it can hold. This amount should be less than the total available storage space
-on the device to give users some wiggle room.
+total amount of bytes it can hold. This amount should be less than the total storage capacity on
+the device to give users some wiggle room. This amount should not reflect the available storage
+space on the device, to avoid facilitating a cross-origin resource size leak.
 
 <p class=note>User agents are strongly encouraged to consider navigation frequency, recency of
 visits, bookmarking, and <a href="#persistence">permission</a> for {{"persistent-storage"}} when


### PR DESCRIPTION
Storage quota should not be based on free disk space, to avoid cross-origin resource size leaks.

<!--
Thank you for contributing to the Storage Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome - we currently grant quota based on total disk space
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/960305
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1552848
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
