### PR TITLE
Make it clear that quota is not supposed to be a function of availabl…

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -478,14 +478,19 @@ rough estimate of the amount of bytes used by it.
 deduplication, compression, and other techniques that obscure exactly how much bytes a
 <a>storage shelf</a> uses.
 
-<p>The <dfn export>storage quota</dfn> of a <a>storage shelf</a> is an <a>implementation-defined</a>
-conservative estimate of the total amount of bytes it can hold. This amount should be less than the
-total storage space on the device. It must not be a function of the available storage space on the
-device.
+<p tracking-vector>The <dfn export>storage quota</dfn> of a <a>storage shelf</a> is an
+<a>implementation-defined</a> conservative estimate of the total amount of bytes it can hold. This
+amount should be less than the total storage space on the device. It must not be a function of the
+available storage space on the device.
 
-<p class=note>User agents are strongly encouraged to consider navigation frequency, recency of
-visits, bookmarking, and <a href="#persistence">permission</a> for {{"persistent-storage"}} when
-determining quotas.
+<div class=note>
+ <p>User agents are strongly encouraged to consider navigation frequency, recency of visits,
+ bookmarking, and <a href="#persistence">permission</a> for {{"persistent-storage"}} when
+ determining quotas.
+
+ <p>Directly or indirectly revealing available storage space can lead to fingerprinting and leaking
+ information outside the scope of the <a for=/>origin</a> involved.
+</div>
 
 
 

--- a/storage.bs
+++ b/storage.bs
@@ -471,20 +471,21 @@ locally.
 
 <h2 id=usage-and-quota>Usage and quota</h2>
 
-<p>The <dfn export>storage usage</dfn> of a <a>storage shelf</a> is a rough estimate of the amount
-of bytes used by it.
+<p>The <dfn export>storage usage</dfn> of a <a>storage shelf</a> is an <a>implementation-defined</a>
+rough estimate of the amount of bytes used by it.
 
 <p class=note>This cannot be an exact amount as user agents might, and are encouraged to, use
 deduplication, compression, and other techniques that obscure exactly how much bytes a
 <a>storage shelf</a> uses.
 
-<p>The <dfn export>storage quota</dfn> of a <a>storage shelf</a> is a conservative estimate of the
-total amount of bytes it can hold. This amount should be less than the total available storage space
-on the device to give users some wiggle room.
+<p>The <dfn export>storage quota</dfn> of a <a>storage shelf</a> is an <a>implementation-defined</a>
+conservative estimate of the total amount of bytes it can hold. This amount should be less than the
+total storage space on the device. It must not be a function of the available storage space on the
+device.
 
 <p class=note>User agents are strongly encouraged to consider navigation frequency, recency of
 visits, bookmarking, and <a href="#persistence">permission</a> for {{"persistent-storage"}} when
-evaluating quotas.
+determining quotas.
 
 
 


### PR DESCRIPTION
…e space

Also make it clear usage and quota for storage shelves are ultimately implementation-defined.

Helps with #95 and #70.

Closes #106.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/108.html" title="Last updated on Jul 7, 2020, 7:56 AM UTC (7bfc8b7)">Preview</a> | <a href="https://whatpr.org/storage/108/a85a7c5...7bfc8b7.html" title="Last updated on Jul 7, 2020, 7:56 AM UTC (7bfc8b7)">Diff</a>