### PR TITLE
Change permission property access status to state

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -54,9 +54,9 @@ Promise.all([
   navigator.storage.persisted(),
   navigator.permissions.query({name: "persistent-storage"})
 ]).then(([persisted, permission]) => {
-  if (!persisted &amp;&amp; permission.status == "granted") {
+  if (!persisted &amp;&amp; permission.state == "granted") {
     navigator.storage.persist().then( /* &hellip; */ );
-  } else if (!persisted &amp;&amp; permission.status == "prompt") {
+  } else if (!persisted &amp;&amp; permission.state == "prompt") {
     showPersistentStorageExplanation();
   }
 });


### PR DESCRIPTION
Browser vendors implemented the permission objects property `status` with `state`.

```
navigator.permissions.query({name: "persistent-storage"}).then(permission => console.log(permission.state, permission))
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/117.html" title="Last updated on Dec 8, 2020, 7:41 AM UTC (8f2a29a)">Preview</a> | <a href="https://whatpr.org/storage/117/1caf370...8f2a29a.html" title="Last updated on Dec 8, 2020, 7:41 AM UTC (8f2a29a)">Diff</a>