### PR TITLE
Editorial: Fix the reference to "persistent-storage".

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -442,7 +442,7 @@ is needed for <a href="https://github.com/whatwg/storage/issues/4">issue #4</a> 
 
 <p>A <a>local storage bucket</a> can only have its <a for="local storage bucket">mode</a> change to
 "<code>persistent</code>" if the user (or user agent on behalf of the user) has granted permission
-to use the {{"persistent-storage"}} feature.
+to use the "{{PermissionName/persistent-storage}}" feature.
 
 <p class="note">When granted to an <a for=/>origin</a>, the persistence permission can be used to
 protect storage from the user agent's clearing policies. The user agent cannot clear storage marked
@@ -450,18 +450,18 @@ as persistent without involvement from the <a for=/>origin</a> or user. This mak
 useful for resources the user needs to have available while offline or resources the user creates
 locally.
 
-<p>The {{"persistent-storage"}}
+<p>The "{{PermissionName/persistent-storage}}"
 <a>powerful feature</a>'s permission-related flags, algorithms, and types are defaulted, except for:
 
 <dl>
  <dt><a>permission state</a>
- <dd><p>{{"persistent-storage"}}'s <a>permission state</a> must have the same value for all
+ <dd><p>"{{PermissionName/persistent-storage}}"'s <a>permission state</a> must have the same value for all
  <a>environment settings objects</a> with a given <a for="environment settings object">origin</a>.
 
  <dt><a>permission revocation algorithm</a>
  <dd algorithm="permission-revocation">
   <ol>
-   <li><p>If {{"persistent-storage"}}'s <a>permission state</a> is {{PermissionState/"granted"}},
+   <li><p>If "{{PermissionName/persistent-storage}}"'s <a>permission state</a> is {{PermissionState/"granted"}},
    then return.
 
    <li><p>Let <var>shelf</var> be the result of running <a>obtain a local storage shelf</a> with
@@ -490,7 +490,7 @@ available storage space on the device.
 
 <div class=note>
  <p>User agents are strongly encouraged to consider navigation frequency, recency of visits,
- bookmarking, and <a href="#persistence">permission</a> for {{"persistent-storage"}} when
+ bookmarking, and <a href="#persistence">permission</a> for "{{PermissionName/persistent-storage}}" when
  determining quotas.
 
  <p>Directly or indirectly revealing available storage space can lead to fingerprinting and leaking
@@ -616,7 +616,7 @@ dictionary StorageEstimate {
   <ol>
    <li>
     <p>Let <var>permission</var> be the result of <a>requesting permission to use</a>
-    {{"persistent-storage"}}.
+    "{{PermissionName/persistent-storage}}".
 
     <p class="note">User agents are encouraged to not let the user answer this question twice for
     the same <a for=/>origin</a> around the same time and this algorithm is not equipped to handle

--- a/storage.bs
+++ b/storage.bs
@@ -13,6 +13,9 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent; url: #sec-agents; type: dfn
     text: agent cluster; url: #sec-agent-clusters; type: dfn
 </pre>
+<pre class=link-defaults>
+spec:permissions-1; type:enum-value; text:"persistent-storage"
+</pre>
 
 
 
@@ -447,7 +450,7 @@ as persistent without involvement from the <a for=/>origin</a> or user. This mak
 useful for resources the user needs to have available while offline or resources the user creates
 locally.
 
-<p>The <dfn for="PermissionName" enum-value>"<code>persistent-storage</code>"</dfn>
+<p>The {{"persistent-storage"}}
 <a>powerful feature</a>'s permission-related flags, algorithms, and types are defaulted, except for:
 
 <dl>


### PR DESCRIPTION
After w3c/permissions#229 moved it to that spec.

It'll be safe to remove the `link-defaults` block once Shepherd has scanned the new dfn-less version of this spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/122.html" title="Last updated on Feb 26, 2021, 12:42 AM UTC (004fe24)">Preview</a> | <a href="https://whatpr.org/storage/122/61cc1ac...004fe24.html" title="Last updated on Feb 26, 2021, 12:42 AM UTC (004fe24)">Diff</a>