### PR TITLE
Editorial: Remove the <pre class=link-defaults> block.

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -13,9 +13,6 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent; url: #sec-agents; type: dfn
     text: agent cluster; url: #sec-agent-clusters; type: dfn
 </pre>
-<pre class=link-defaults>
-spec:permissions-1; type:enum-value; text:"persistent-storage"
-</pre>
 
 
 


### PR DESCRIPTION
It's unnecessary now that Shepherd has picked up the latest version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/123.html" title="Last updated on Feb 26, 2021, 6:17 PM UTC (c3ddb57)">Preview</a> | <a href="https://whatpr.org/storage/123/6395f44...c3ddb57.html" title="Last updated on Feb 26, 2021, 6:17 PM UTC (c3ddb57)">Diff</a>