### PR TITLE
Editorial: Minor Permissions-related edits

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -439,7 +439,7 @@ is needed for <a href="https://github.com/whatwg/storage/issues/4">issue #4</a> 
 
 <p>A <a>local storage bucket</a> can only have its <a for="local storage bucket">mode</a> change to
 "<code>persistent</code>" if the user (or user agent on behalf of the user) has granted permission
-to use the "{{PermissionName/persistent-storage}}" feature.
+to use the "{{PermissionName/persistent-storage}}" <a>powerful feature</a>.
 
 <p class="note">When granted to an <a for=/>origin</a>, the persistence permission can be used to
 protect storage from the user agent's clearing policies. The user agent cannot clear storage marked
@@ -448,18 +448,19 @@ useful for resources the user needs to have available while offline or resources
 locally.
 
 <p>The "{{PermissionName/persistent-storage}}"
-<a>powerful feature</a>'s permission-related flags, algorithms, and types are defaulted, except for:
+<a>powerful feature</a>'s permission-related algorithms, and types are defaulted, except for:
 
 <dl>
  <dt><a>permission state</a>
- <dd><p>"{{PermissionName/persistent-storage}}"'s <a>permission state</a> must have the same value for all
- <a>environment settings objects</a> with a given <a for="environment settings object">origin</a>.
+ <dd><p>"{{PermissionName/persistent-storage}}"'s <a>permission state</a> must have the same value
+ for all <a>environment settings objects</a> with a given
+ <a for="environment settings object">origin</a>.
 
  <dt><a>permission revocation algorithm</a>
  <dd algorithm="permission-revocation">
   <ol>
-   <li><p>If "{{PermissionName/persistent-storage}}"'s <a>permission state</a> is {{PermissionState/"granted"}},
-   then return.
+   <li><p>If the result of <a>getting the current permission state</a> with
+   "{{PermissionName/persistent-storage}}" is {{PermissionState/"granted"}}, then return.
 
    <li><p>Let <var>shelf</var> be the result of running <a>obtain a local storage shelf</a> with
    <a>current settings object</a>.
@@ -487,8 +488,8 @@ available storage space on the device.
 
 <div class=note>
  <p>User agents are strongly encouraged to consider navigation frequency, recency of visits,
- bookmarking, and <a href="#persistence">permission</a> for "{{PermissionName/persistent-storage}}" when
- determining quotas.
+ bookmarking, and <a href="#persistence">permission</a> for "{{PermissionName/persistent-storage}}"
+ when determining quotas.
 
  <p>Directly or indirectly revealing available storage space can lead to fingerprinting and leaking
  information outside the scope of the <a for=/>origin</a> involved.
@@ -705,6 +706,7 @@ Kenji Baheux,
 Kinuko Yasuda,
 Luke Wagner,
 Michael Nordman,
+Mike Taylor,
 Mounir Lamouri,
 Shachar Zohar,
 黃強 (Shawn Huang),


### PR DESCRIPTION
- Consistently refer to "persistent-storage" as a <a>powerful feature</a>
- Use <a>getting the current permission state</a> in the permission revocation
algorithm.
- Remove reference to powerful feature flags (as there are none anymore)
- Whitespace tweaks


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/129.html" title="Last updated on Nov 23, 2021, 11:31 PM UTC (6510919)">Preview</a> | <a href="https://whatpr.org/storage/129/4db72fe...6510919.html" title="Last updated on Nov 23, 2021, 11:31 PM UTC (6510919)">Diff</a>