### PR TITLE
Add 'obtain a storage key for non-storage purposes'

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -198,7 +198,8 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 
 <h3 id=storage-keys>Storage keys</h3>
 
-<p>A <dfn>storage key</dfn> is an <a for=/>origin</a>. [[!HTML]]
+<p>A <dfn>storage key</dfn> is a <a>tuple</a> consisting of an <dfn for="storage key">origin</dfn>
+(an <a for=/>origin</a>). [[!HTML]]
 
 <p class=XXX>This is expected to change; see
 <a href="https://privacycg.github.io/storage-partitioning/">Client-Side Storage Partitioning</a>.
@@ -207,22 +208,22 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 <var>environment</var>, run these steps:
 
 <ol>
- <li><p>Let <var>origin</var> be <var>environment</var>'s
- <a for="environment settings object">origin</a>.
+ <li><p>Let <var>key</var> be the result of running <a>obtain a storage key for non-storage
+ purposes</a> with <var>environment</var>.
 
- <li><p>If <var>origin</var> is an <a>opaque origin</a>, then return failure.
+ <li><p>If <var>key</var>'s <a for="storage key">origin</a> is an <a>opaque origin</a>, then return
+ failure.
 
  <li><p>If the user has disabled storage, then return failure.
 
- <li><p>Return the result of running <a>obtain a storage key for non-storage purposes</a> with
- <var>environment</var>.
+ <li><p>Return <var>key</var>.
 </ol>
 
 <p>To <dfn export>obtain a storage key for non-storage purposes</dfn>, given an <a>environment
 settings object</a> <var>environment</var>, run these steps:
 
 <ol>
- <li><p>Let <var>key</var> be <var>environment</var>'s
+ <li><p>Let <var>key</var> be a <a>tuple</a> consisting of <var>environment</var>'s
  <a for="environment settings object">origin</a>.
 
  <li><p>Return <var>key</var>.

--- a/storage.bs
+++ b/storage.bs
@@ -208,7 +208,7 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 <var>environment</var>, run these steps:
 
 <ol>
- <li><p>Let <var>key</var> be the result of running 
+ <li><p>Let <var>key</var> be the result of running
  <a>obtain a storage key for non-storage purposes</a> with <var>environment</var>.
 
  <li><p>If <var>key</var>'s <a for="storage key">origin</a> is an <a>opaque origin</a>, then return

--- a/storage.bs
+++ b/storage.bs
@@ -203,6 +203,16 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 <p class=XXX>This is expected to change; see
 <a href="https://privacycg.github.io/storage-partitioning/">Client-Side Storage Partitioning</a>.
 
+<p>To <dfn export>obtain a storage key for non-storage purposes</dfn>, given an <a>environment
+settings object</a> <var>environment</var>, run these steps:
+
+<ol>
+ <li><p>Let <var>key</var> be <var>environment</var>'s
+ <a for="environment settings object">origin</a>.
+
+ <li><p>Return <var>key</var>.
+</ol>
+
 <p>To <dfn export>obtain a storage key</dfn>, given an <a>environment settings object</a>
 <var>environment</var>, run these steps:
 
@@ -214,7 +224,8 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 
  <li><p>If the user has disabled storage, then return failure.
 
- <li><p>Return <var>key</var>.
+ <li><p>Return the result of running <a>obtain a storage key for non-storage purposes</a> with
+ <var>environment</var>.
 </ol>
 
 

--- a/storage.bs
+++ b/storage.bs
@@ -208,8 +208,8 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 <var>environment</var>, run these steps:
 
 <ol>
- <li><p>Let <var>key</var> be the result of running <a>obtain a storage key for non-storage
- purposes</a> with <var>environment</var>.
+ <li><p>Let <var>key</var> be the result of running 
+ <a>obtain a storage key for non-storage purposes</a> with <var>environment</var>.
 
  <li><p>If <var>key</var>'s <a for="storage key">origin</a> is an <a>opaque origin</a>, then return
  failure.

--- a/storage.bs
+++ b/storage.bs
@@ -203,6 +203,21 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 <p class=XXX>This is expected to change; see
 <a href="https://privacycg.github.io/storage-partitioning/">Client-Side Storage Partitioning</a>.
 
+<p>To <dfn export>obtain a storage key</dfn>, given an <a>environment settings object</a>
+<var>environment</var>, run these steps:
+
+<ol>
+ <li><p>Let <var>origin</var> be <var>environment</var>'s
+ <a for="environment settings object">origin</a>.
+
+ <li><p>If <var>origin</var> is an <a>opaque origin</a>, then return failure.
+
+ <li><p>If the user has disabled storage, then return failure.
+
+ <li><p>Return the result of running <a>obtain a storage key for non-storage purposes</a> with
+ <var>environment</var>.
+</ol>
+
 <p>To <dfn export>obtain a storage key for non-storage purposes</dfn>, given an <a>environment
 settings object</a> <var>environment</var>, run these steps:
 
@@ -211,21 +226,6 @@ settings object</a> <var>environment</var>, run these steps:
  <a for="environment settings object">origin</a>.
 
  <li><p>Return <var>key</var>.
-</ol>
-
-<p>To <dfn export>obtain a storage key</dfn>, given an <a>environment settings object</a>
-<var>environment</var>, run these steps:
-
-<ol>
- <li><p>Let <var>key</var> be <var>environment</var>'s
- <a for="environment settings object">origin</a>.
-
- <li><p>If <var>key</var> is an <a>opaque origin</a>, then return failure.
-
- <li><p>If the user has disabled storage, then return failure.
-
- <li><p>Return the result of running <a>obtain a storage key for non-storage purposes</a> with
- <var>environment</var>.
 </ol>
 
 


### PR DESCRIPTION
Fixes #131 

This commit adds a new algorithm for obtaining a storage key that is suitable for use in non-storage APIs (for instance, BroadcastChannel). Specifically, this algorithm works regardless of whether storage access has been granted and also allows a storage key to be obtained for opaque origins.

I don't think tests or implementation bugs are needed for this change since this PR maintains the existing functionality of "obtain a storage key" and doesn't use "obtain a storage key for non-storage purposes".  If this is not the case let me know and I'm happy to write tests / open implementation bugs.

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Not required
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: Not required
   * Firefox: Not required
   * Safari: Not required


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/132.html" title="Last updated on Feb 10, 2022, 9:19 AM UTC (df8494f)">Preview</a> | <a href="https://whatpr.org/storage/132/fa1e944...df8494f.html" title="Last updated on Feb 10, 2022, 9:19 AM UTC (df8494f)">Diff</a>