### PR TITLE
Add a storage key comparison algorithm

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -229,6 +229,17 @@ settings object</a> <var>environment</var>, run these steps:
  <li><p>Return <var>key</var>.
 </ol>
 
+<p>To determine whether a <a>storage key</a> <var>A</var>
+<dfn export for="storage key" id=concept-storage-key-equals lt=equal>equals</dfn> <var>B</var>, run
+these steps:
+
+<ol>
+ <li><p>If <var>A</var>'s <a for="storage key">origin</a> is not <a lt="same origin">same-origin</a>
+ with <var>B</var>'s <a for="storage key">origin</a>, then return false.
+
+ <li><p>Return true.
+</ol>
+
 
 <h3 id=storage-sheds>Storage sheds</h3>
 
@@ -702,6 +713,7 @@ Aislinn Grigas,
 Alex Russell,
 Ali Alabbas,
 Andrew Sutherland,
+Andrew Williams,
 Ben Kelly,
 Ben Turner,
 Dale Harvey,

--- a/storage.bs
+++ b/storage.bs
@@ -230,12 +230,12 @@ settings object</a> <var>environment</var>, run these steps:
 </ol>
 
 <p>To determine whether a <a>storage key</a> <var>A</var>
-<dfn export for="storage key" id=concept-storage-key-equals lt=equal>equals</dfn> <var>B</var>, run
-these steps:
+<dfn export for="storage key" lt=equal>equals</dfn> <a>storage key</a> <var>B</var>, run these
+steps:
 
 <ol>
- <li><p>If <var>A</var>'s <a for="storage key">origin</a> is not <a lt="same origin">same-origin</a>
- with <var>B</var>'s <a for="storage key">origin</a>, then return false.
+ <li><p>If <var>A</var>'s <a for="storage key">origin</a> is not <a>same origin</a> with
+ <var>B</var>'s <a for="storage key">origin</a>, then return false.
 
  <li><p>Return true.
 </ol>


### PR DESCRIPTION
This PR adds and exports an algorithm for comparing two storage keys. This will be useful for non-storage APIs that want to partition state using storage keys.

Also, adding my name to the 'Acknowledgments' section since I forgot to do this with my previous PR. :D

Fixes #133 

I don't think tests or implementation bugs are needed for this change since this PR doesn't change any existing functionality.

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Not required
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: Not required
   * Firefox: Not required
   * Safari: Not required


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/134.html" title="Last updated on Feb 11, 2022, 4:56 PM UTC (c32e7a2)">Preview</a> | <a href="https://whatpr.org/storage/134/c68c384...c32e7a2.html" title="Last updated on Feb 11, 2022, 4:56 PM UTC (c32e7a2)">Diff</a>