### PR TITLE
Define a storage task source

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -472,9 +472,15 @@ is needed for <a href="https://github.com/whatwg/storage/issues/4">issue #4</a> 
 
 <h3 id=storage-task-source>Storage task source</h2>
 
-<p>The <dfn export>storage task source</dfn> is a <a for=/>task source</a> to be used for all
-<a for=/>tasks</a> related to a <a>storage endpoint</a>. In particular those that relate to a
-<a>storage endpoint</a>'s <a for="storage endpoint">quota</a>.
+<p>The <dfn export id=task-source>storage task source</dfn> is a <a for=/>task source</a> to be used
+for all <a for=/>tasks</a> related to a <a>storage endpoint</a>. In particular those that relate to
+a <a>storage endpoint</a>'s <a for="storage endpoint">quota</a>.
+
+<div algorithm>
+<p>To <dfn export>queue a storage task</dfn> given a <a for=/>global object</a> <var>global</var>
+and a series of steps <var>steps</var>, <a>queue a global task</a> on the <a>storage task source</a>
+with <var>global</var> and <var>steps</var>.
+</div>
 
 
 
@@ -613,15 +619,19 @@ dictionary StorageEstimate {
 };
 </pre>
 
+<div algorithm>
 <p>The <dfn method for=StorageManager><code>persisted()</code></dfn> method steps are:
 
 <ol>
- <li><p>Let <var>promise</var> be a new promise.
+ <li><p>Let <var>promise</var> be <a>a new promise</a>.
+
+ <li><p>Let <var>global</var> be <a>this</a>'s <a>relevant global object</a>.
 
  <li><p>Let <var>shelf</var> be the result of running <a>obtain a local storage shelf</a> with
  <a>this</a>'s <a>relevant settings object</a>.
 
- <li><p>If <var>shelf</var> is failure, then reject <var>promise</var> with a {{TypeError}}.
+ <li><p>If <var>shelf</var> is failure, then <a for=/>reject</a> <var>promise</var> with a
+ {{TypeError}}.
 
  <li>
   <p>Otherwise, run these steps <a>in parallel</a>:
@@ -634,21 +644,27 @@ dictionary StorageEstimate {
 
     <p class=note>It will be false when there's an internal error.
 
-   <li><p><a>Queue a task</a> to resolve <var>promise</var> with <var>persisted</var>.
+   <li><p><a>Queue a storage task</a> with <var>global</var> to <a for=/>resolve</a>
+   <var>promise</var> with <var>persisted</var>.
   </ol>
 
  <li><p>Return <var>promise</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>The <dfn method for=StorageManager><code>persist()</code></dfn> method steps are:
 
 <ol>
- <li><p>Let <var>promise</var> be a new promise.
+ <li><p>Let <var>promise</var> be <a>a new promise</a>.
+
+ <li><p>Let <var>global</var> be <a>this</a>'s <a>relevant global object</a>.
 
  <li><p>Let <var>shelf</var> be the result of running <a>obtain a local storage shelf</a> with
  <a>this</a>'s <a>relevant settings object</a>.
 
- <li><p>If <var>shelf</var> is failure, then reject <var>promise</var> with a {{TypeError}}.
+ <li><p>If <var>shelf</var> is failure, then <a for=/>reject</a> <var>promise</var> with a
+ {{TypeError}}.
 
  <li>
   <p>Otherwise, run these steps <a>in parallel</a>:
@@ -681,21 +697,27 @@ dictionary StorageEstimate {
      <li><p>If there was no internal error, then set <var>persisted</var> to true.
     </ol>
 
-   <li><p><a>Queue a task</a> to resolve <var>promise</var> with <var>persisted</var>.
+   <li><p><a>Queue a storage task</a> with <var>global</var> to <a for=/>resolve</a>
+   <var>promise</var> with <var>persisted</var>.
   </ol>
 
  <li><p>Return <var>promise</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>The <dfn method for=StorageManager><code>estimate()</code></dfn> method steps are:
 
 <ol>
- <li><p>Let <var>promise</var> be a new promise.
+ <li><p>Let <var>promise</var> be <a>a new promise</a>.
+
+ <li><p>Let <var>global</var> be <a>this</a>'s <a>relevant global object</a>.
 
  <li><p>Let <var>shelf</var> be the result of running <a>obtain a local storage shelf</a> with
  <a>this</a>'s <a>relevant settings object</a>.
 
- <li><p>If <var>shelf</var> is failure, then reject <var>promise</var> with a {{TypeError}}.
+ <li><p>If <var>shelf</var> is failure, then <a for=/>reject</a> <var>promise</var> with a
+ {{TypeError}}.
 
  <li>
   <p>Otherwise, run these steps <a>in parallel</a>:
@@ -710,17 +732,20 @@ dictionary StorageEstimate {
 
    <li>
     <p>If there was an internal error while obtaining <var>usage</var> and <var>quota</var>, then
-    <a>queue a task</a> to reject <var>promise</var> with a {{TypeError}}.
+    <a>queue a storage task</a> with <var>global</var> to <a for=/>reject</a> <var>promise</var>
+    with a {{TypeError}}.
 
     <p class=note>Internal errors are supposed to be extremely rare and indicate some kind of
     low-level platform or hardware fault. However, at the scale of the web with the diversity of
     implementation and platforms, the unexpected does occur.
 
-   <li><p>Otherwise, <a>queue a task</a> to resolve <var>promise</var> with <var>dictionary</var>.
+   <li><p>Otherwise, <a>queue a storage task</a> with <var>global</var> to <a for=/>resolve</a>
+   <var>promise</var> with <var>dictionary</var>.
   </ol>
 
  <li><p>Return <var>promise</var>.
 </ol>
+</div>
 
 
 

--- a/storage.bs
+++ b/storage.bs
@@ -713,6 +713,16 @@ dictionary StorageEstimate {
 
 
 
+<h2 id=the-storage-task-source>The Storage Task Source</h2>
+
+<p>This specification defines a new generic task source called the
+<dfn export id="storage-task-source">storage task source</dfn>, which is to be
+used for all tasks that are queued by a <a>storage endpoint</a> which may modify
+or are dependent on the value of the <var>endpoint</var>'s
+<a for="storage endpoint">quota</a>.
+
+
+
 <h2 class=no-num id="acks">Acknowledgments</h2>
 
 <p>With that, many thanks to
@@ -722,6 +732,7 @@ Alex Russell,
 Ali Alabbas,
 Andrew Sutherland,
 Andrew Williams,
+Austin Sullivan,
 Ben Kelly,
 Ben Turner,
 Dale Harvey,

--- a/storage.bs
+++ b/storage.bs
@@ -14,6 +14,10 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent cluster; url: #sec-agent-clusters; type: dfn
 </pre>
 
+<pre class=link-defaults>
+spec:infra; type:dfn; text:implementation-defined
+</pre>
+
 
 
 <h2 id=introduction>Introduction</h2>
@@ -466,6 +470,13 @@ is needed for <a href="https://github.com/whatwg/storage/issues/4">issue #4</a> 
 <a href="https://privacycg.github.io/storage-access/">Storage Access API</a>.
 
 
+<h3 id=storage-task-source>Storage task source</h2>
+
+<p>The <dfn export>storage task source</dfn> is a <a for=/>task source</a> to be used for all
+<a for=/>tasks</a> related to a <a>storage endpoint</a>. In particular those that relate to a
+<a>storage endpoint</a>'s <a for="storage endpoint">quota</a>.
+
+
 
 <h2 id=persistence>Persistence permission</h2>
 
@@ -710,16 +721,6 @@ dictionary StorageEstimate {
 
  <li><p>Return <var>promise</var>.
 </ol>
-
-
-
-<h2 id=the-storage-task-source>The Storage Task Source</h2>
-
-<p>This specification defines a new generic task source called the
-<dfn export id="storage-task-source">storage task source</dfn>, which is to be
-used for all tasks that are queued by a <a>storage endpoint</a> which may modify
-or are dependent on the value of the <var>endpoint</var>'s
-<a for="storage endpoint">quota</a>.
 
 
 

--- a/storage.bs
+++ b/storage.bs
@@ -14,10 +14,6 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent cluster; url: #sec-agent-clusters; type: dfn
 </pre>
 
-<pre class=link-defaults>
-spec:infra; type:dfn; text:implementation-defined
-</pre>
-
 
 
 <h2 id=introduction>Introduction</h2>

--- a/storage.bs
+++ b/storage.bs
@@ -14,6 +14,10 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent cluster; url: #sec-agent-clusters; type: dfn
 </pre>
 
+<pre class=link-defaults>
+spec:infra; type:dfn; text:implementation-defined
+</pre>
+
 
 
 <h2 id=introduction>Introduction</h2>


### PR DESCRIPTION
See https://github.com/whatwg/fs/issues/3

Writes using any storage API should be rejected if the site is out of quota. Therefore all writes from storage APIs which may affect or be affected by quota should run in order (at least per-site)

Fixes #89


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/155.html" title="Last updated on Jan 16, 2023, 7:40 AM UTC (a522e54)">Preview</a> | <a href="https://whatpr.org/storage/155/8b93c4c...a522e54.html" title="Last updated on Jan 16, 2023, 7:40 AM UTC (a522e54)">Diff</a>