### PR TITLE
Editorial: Export storage keys, their origins, and storage sheds.

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -205,8 +205,8 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 
 <h3 id=storage-keys>Storage keys</h3>
 
-<p>A <dfn>storage key</dfn> is a <a>tuple</a> consisting of an <dfn for="storage key">origin</dfn>
-(an <a for=/>origin</a>). [[!HTML]]
+<p>A <dfn export>storage key</dfn> is a <a>tuple</a> consisting of an
+<dfn for="storage key" export>origin</dfn> (an <a for=/>origin</a>). [[!HTML]]
 
 <p class=XXX>This is expected to change; see
 <a href="https://privacycg.github.io/storage-partitioning/">Client-Side Storage Partitioning</a>.
@@ -252,8 +252,8 @@ steps:
 
 <h3 id=storage-sheds>Storage sheds</h3>
 
-<p>A <dfn>storage shed</dfn> is a <a for=/>map</a> of <a>storage keys</a> to <a>storage shelves</a>.
-It is initially empty.
+<p>A <dfn export>storage shed</dfn> is a <a for=/>map</a> of <a>storage keys</a> to
+<a>storage shelves</a>. It is initially empty.
 
 <hr>
 


### PR DESCRIPTION
This is to support https://github.com/privacycg/nav-tracking-mitigations/pull/37. That PR doesn't strictly need "storage key" exported, but it seemed weird to export a field without exporting the tuple. 
