### PR TITLE
Meta: export keys, sheds, and bottles

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -472,7 +472,7 @@ is needed for <a href="https://github.com/whatwg/storage/issues/4">issue #4</a> 
 <a href="https://privacycg.github.io/storage-access/">Storage Access API</a>.
 
 
-<h3 id=storage-task-source>Storage task source</h2>
+<h3 id=storage-task-source>Storage task source</h3>
 
 <p>The <dfn export id=task-source>storage task source</dfn> is a <a for=/>task source</a> to be used
 for all <a for=/>tasks</a> related to a <a>storage endpoint</a>. In particular those that relate to

--- a/storage.bs
+++ b/storage.bs
@@ -206,8 +206,8 @@ anticipated that some APIs will be applicable to both <a>storage types</a> going
 
 <h3 id=storage-keys>Storage keys</h3>
 
-<p>A <dfn>storage key</dfn> is a <a>tuple</a> consisting of an <dfn for="storage key">origin</dfn>
-(an <a for=/>origin</a>). [[!HTML]]
+<p>A <dfn export>storage key</dfn> is a <a>tuple</a> consisting of an
+<dfn for="storage key">origin</dfn> (an <a for=/>origin</a>). [[!HTML]]
 
 <p class=XXX>This is expected to change; see
 <a href="https://privacycg.github.io/storage-partitioning/">Client-Side Storage Partitioning</a>.
@@ -253,8 +253,8 @@ steps:
 
 <h3 id=storage-sheds>Storage sheds</h3>
 
-<p>A <dfn>storage shed</dfn> is a <a for=/>map</a> of <a>storage keys</a> to <a>storage shelves</a>.
-It is initially empty.
+<p>A <dfn export>storage shed</dfn> is a <a for=/>map</a> of <a>storage keys</a> to
+<a>storage shelves</a>. It is initially empty.
 
 <hr>
 
@@ -393,7 +393,7 @@ steps:
 
 <h3 id=storage-bottles>Storage bottles</h3>
 
-<p>A <dfn>storage bottle</dfn> is a part of a <a>storage bucket</a> carved out for a single
+<p>A <dfn export>storage bottle</dfn> is a part of a <a>storage bucket</a> carved out for a single
 <a>storage endpoint</a>. A <a>storage bottle</a> has a <dfn for="storage bottle">map</dfn>, which is
 initially an empty <a for=/>map</a>. A <a>storage bottle</a> also has a
 <dfn for="storage bottle">proxy map reference set</dfn>, which is initially an empty


### PR DESCRIPTION
Closes #162 by superseding it. /cc @jyasskin. (I was going to encourage that to get merged and then do mine on top, but then I saw that the CI was stalled for some reason, which I didn't want to make you bother to figure out.)

https://github.com/webmachinelearning/writing-assistance-apis/pull/47 will use "storage key" and "storage bottle", if you're curious. It sounds like https://github.com/privacycg/nav-tracking-mitigations/pull/37 wants to use "storage sheds".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/179.html" title="Last updated on Mar 19, 2025, 8:07 AM UTC (4f9d133)">Preview</a> | <a href="https://whatpr.org/storage/179/39f5138...4f9d133.html" title="Last updated on Mar 19, 2025, 8:07 AM UTC (4f9d133)">Diff</a>