### PR TITLE
Fix markup error

### DIFF
--- a/storage.bs
+++ b/storage.bs
@@ -406,7 +406,7 @@ initially an empty <a for=/>map</a>. A <a>storage bottle</a> also has a
 <a for=/>set</a>. A <a>storage bottle</a> also has a <dfn for="storage bottle">quota</dfn>, which is
 null or a number representing a conservative estimate of the total amount of bytes it can hold. Null
 indicates the lack of a limit. <span class=note>It is still bound by the <a>storage quota</a> of its
-encompassing <a for=/>storage shelf</a>.
+encompassing <a for=/>storage shelf</a>.</span>
 
 <p>A <a>storage bottle</a>'s <a for="storage bottle">map</a> is where the actual data meant to be
 stored lives. User agents are expected to store this data, and make it available across <a>agent</a>


### PR DESCRIPTION
Needed to close a `<span>`. (This is caught by the next major Bikeshed release.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/storage/189.html" title="Last updated on Dec 2, 2025, 9:31 PM UTC (adfa6d9)">Preview</a> | <a href="https://whatpr.org/storage/189/00b7760...adfa6d9.html" title="Last updated on Dec 2, 2025, 9:31 PM UTC (adfa6d9)">Diff</a>